### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/et-collector/values.yaml
+++ b/src/et-collector/values.yaml
@@ -80,7 +80,6 @@ ingress:
 
 resources:
   limits:
-    cpu: 1
     memory: 2Gi
   requests:
     cpu: 100m

--- a/src/et-receiver/values.yaml
+++ b/src/et-receiver/values.yaml
@@ -85,7 +85,6 @@ securityContext:
 
 resources:
   limits:
-    cpu: 2
     memory: 2Gi
   requests:
     cpu: 100m


### PR DESCRIPTION
As per best practices, utilizing requests.cpu and removing limits.cpu

Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)